### PR TITLE
Better find + xargs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ function someFunction(a, b) {
 Want to convert your whole project to ES6 syntax for even greater awesomeness? No problem!
 
 ```
-$ find . -name "*.js" | xargs -0 -I % xto6 % -o %
+$ find . -type f -not -path "*node_modules*" -name "*.js" -print0 | xargs -0 -I % xto6 % -o %
 ```
 
 


### PR DESCRIPTION
1. Without `-print0` it was throwing the ` xargs: insufficient space for argument`
2. Ignoring `node_modules` folder... :wink: