### PR TITLE
add main file

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+exports.Transformer = require('./lib/transformer');


### PR DESCRIPTION
Your `package.json` describes `"main": "index.js"` but `index.js` file didn't exist.
This allows us to require and use xto6 in Node.js.