### PR TITLE
consider update_expression to determine let/const

### DIFF
--- a/src/transformation/let.js
+++ b/src/transformation/let.js
@@ -23,5 +23,10 @@ function replaceVar(node) {
     if (declarations[left]) {
       declarations[left].kind = 'let';
     }
+  } else if (node.type === 'UpdateExpression') {
+    let name = node.argument.name;
+    if (declarations[name]) {
+      declarations[name].kind = 'let';
+    }
   }
 }

--- a/test/transformation/let.js
+++ b/test/transformation/let.js
@@ -35,4 +35,9 @@ describe('Variable declaration var to let/const', function () {
     var script = 'x = 2; this.y = 5';
     expect(test(script)).to.equal('x = 2;\nthis.y = 5;');
   });
+
+  it('should use let for updated variables', function () {
+    var script = 'var i = 0; i++;'
+    expect(test(script)).to.equal('let i = 0;\ni++;');
+  });
 });


### PR DESCRIPTION
currently `var i = 0; i++;` is transformed to `const i = 0; i++;` but `let` should be used in this case, so I fixed it.