### PR TITLE
Proposal: use `benjamn/recast` instead of `acorn` and `escodegen`

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,15 +30,14 @@
   },
   "homepage": "https://github.com/mohebifar/xto6",
   "dependencies": {
-    "acorn": "^0.11.0",
     "babel": "^5.0.12",
     "coffee-script": "^1.9.1",
     "commander": "^2.6.0",
-    "escodegen": "^1.6.1",
     "esformatter": "^0.6.1",
     "estraverse": "^1.9.1",
     "esutils": "^1.1.6",
-    "lodash": "^3.3.1"
+    "lodash": "^3.3.1",
+    "recast": "^0.10.39"
   },
   "devDependencies": {
     "chai": "^2.2.0",

--- a/src/transformer.js
+++ b/src/transformer.js
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import merge from 'lodash/object/merge.js';
-import codeGenerator from 'escodegen';
+import recast from 'recast';
 import formatter from 'esformatter';
 import astGenerator from './utils/ast-generator.js';
 
@@ -105,9 +105,8 @@ class Transformer {
    *
    * @returns {Object}
    */
-    out() {
-    let result;
-    result = codeGenerator.generate(this.ast, {comment: true});
+  out() {
+    let result = recast.print(this.ast).code;
 
     if(this.options.formatter !== false) {
       result = formatter.format(result, this.options.formatter);

--- a/src/utils/ast-generator.js
+++ b/src/utils/ast-generator.js
@@ -1,5 +1,4 @@
-import acorn from 'acorn';
-import escodegen from 'escodegen';
+import recast from 'recast';
 import fs from 'fs';
 import coffee from 'coffee-script';
 
@@ -40,25 +39,11 @@ export function readFile(file, options) {
  * @returns {Object}
  */
 export function read(js, options) {
-  let hashbang = js.indexOf('#!');
-  if (hashbang > -1) {
-    js = js.slice(0, hashbang) + js.slice(js.indexOf('\n', hashbang));
-  }
-
-  let comments = [];
-  let tokens = [];
-
-  options.ranges = true;
-  options.onComment = comments;
-  options.onToken = tokens;
-
   if (options.coffee) {
     js = coffee.compile(js);
   }
 
-  let ast = acorn.parse(js, options);
-
-  escodegen.attachComments(ast, comments, tokens);
+  let ast = recast.parse(js).program;
 
   return ast;
 }


### PR DESCRIPTION
Related to #32 .

I'm working on transforming our ES5 code to ES2015, typically `var` to `let` and `const`. We want to maintain the whole structure of our code except those changes, so `benjamn/recast` is better for our use.
So I tried to replace `acorn`, `escodegen` to `recast` and it worked fine in local.

This is only a proposal so I've not fixed test code yet, but I'd like to do it if you want to merge this.
Thanks.